### PR TITLE
Fixes "no implicit conversion of nil into String" error

### DIFF
--- a/app/helpers/table_format.rb
+++ b/app/helpers/table_format.rb
@@ -110,7 +110,7 @@ module TableFormat
 
   # Prepares date view
   def dateView(t, doc)
-    return '<span class="date">'+ t["Human Readable Name"]+ ': <span class="list_date">'+doc[t["Field Name"]]+'</span></span>'
+    return '<span class="date">'+ t["Human Readable Name"]+ ': <span class="list_date">'+doc[t["Field Name"]].to_s+'</span></span>'
   end
 
   # Prepares title view


### PR DESCRIPTION
When loading the Snowden document search, line #18 of `/var/www/LookingGlass/app/views/docs/_list.html.erb` raised an error because of this.